### PR TITLE
Fix #26 for 1.19 branch

### DIFF
--- a/fabric/src/main/java/com/starfish_studios/naturalist/fabric/NaturalistFabric.java
+++ b/fabric/src/main/java/com/starfish_studios/naturalist/fabric/NaturalistFabric.java
@@ -99,7 +99,7 @@ public class NaturalistFabric implements ModInitializer {
     void removeSpawn(TagKey<Biome> tag, List<EntityType<?>> entityTypes) {
         entityTypes.forEach(entityType -> {
             ResourceLocation id = Registry.ENTITY_TYPE.getKey(entityType);
-            Preconditions.checkState(id != Registry.ENTITY_TYPE.getDefaultKey(), "Unregistered entity type: %s", entityType);
+            Preconditions.checkState(Registry.ENTITY_TYPE.containsKey(id), "Unregistered entity type: %s", entityType);
             BiomeModifications.create(id).add(ModificationPhase.REMOVALS, biomeSelector -> biomeSelector.hasTag(tag), context -> context.getSpawnSettings().removeSpawnsOfEntityType(entityType));
         });
     }


### PR DESCRIPTION
Changes entity type spawn removal on Fabric to check if the registry contains the id instead of comparing object references with the default id.

Fixes #26
Closes Virtuoel/Statement#20
Also closes dhyces/wart-decay#2

Could probably cherry pick this onto the other branches?
